### PR TITLE
feat: refactoring InterchainProposalExecutor

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are two essential contracts in this interchain extension:
 
 1. `InterchainProposalSender`: Deployed on the source chain, this contract has a method called `executeRemoteProposal`. This method encodes a proposal into a payload for a remote chain and pays the Axelar Gas Service for the execution of the interchain call on the destination chain.
 
-2. `InterchainProposalExecutor`: Deployed on the destination chain, this contract has a callback method `_execute` that executes the proposal on the target contracts.
+2. `ProposalExecutor`: Deployed on the destination chain, this contract has a callback method `_execute` that executes the proposal on the target contracts.
 
 For a visual transaction flow of the interchain proposal, see the mermaid diagram below.
 
@@ -16,7 +16,7 @@ For a visual transaction flow of the interchain proposal, see the mermaid diagra
 flowchart
     subgraph "Destination Chain Contracts"
         direction TB
-        PE{{InterchainProposalExecutor Contract}}
+        PE{{ProposalExecutor Contract}}
         PE -.->|Calls| TargetA
         PE -->|Calls| TargetB
         PE -.->|Calls| Target
@@ -63,7 +63,7 @@ Once you're comfortable with the process, use the deployed addresses to integrat
 
 ## Interchain Proposal Execution
 
-In order to execute interchain proposals, deploy your instance of `InterchainProposalSender`. Alternatively, use our predefined contract for the testnet listed below. On the destination chain, deploy `InterchainProposalExecutor` and set up access control for whitelisted senders from the source chain.
+In order to execute interchain proposals, deploy your instance of `InterchainProposalSender`. Alternatively, use our predefined contract for the testnet listed below. On the destination chain, deploy `ProposalExecutor` and set up access control for whitelisted senders from the source chain.
 
 | Chain     | InterchainProposalSender address           |
 | --------- | ------------------------------------------ |

--- a/contracts/ProposalExecutor.sol
+++ b/contracts/ProposalExecutor.sol
@@ -10,6 +10,8 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./executor/AxelarProposalExecutor.sol";
 
 contract ProposalExecutor is AxelarProposalExecutor, ReentrancyGuard {
+
+
     function _executeProposal(
         bytes memory payload
     ) internal override nonReentrant {
@@ -43,7 +45,7 @@ contract ProposalExecutor is AxelarProposalExecutor, ReentrancyGuard {
                     }
                 } else {
                     // There is no failure data, just revert with no reason.
-                    revert("ProposalExecutor: call failed");
+                    revert ProposalExecuteFailed();
                 }
             }
         }

--- a/contracts/ProposalExecutor.sol
+++ b/contracts/ProposalExecutor.sol
@@ -1,0 +1,35 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
+import "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarExecutable.sol";
+import "@axelar-network/axelar-gmp-sdk-solidity/contracts/utils/AddressString.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "./executor/AxelarProposalExecutor.sol";
+
+contract ProposalExecutor is AxelarProposalExecutor {
+    function _executeProposal(bytes memory payload) internal override {
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            string[] memory signatures,
+            bytes[] memory data
+        ) = abi.decode(payload, (address[], uint256[], string[], bytes[]));
+
+        // Iterate over all targets and call them with the given data
+        for (uint256 i = 0; i < targets.length; i++) {
+            // Construct the call data
+            bytes memory callData = abi.encodePacked(
+                bytes4(keccak256(bytes(signatures[i]))),
+                data[i]
+            );
+
+            // Call the target
+            (bool success, ) = targets[i].call{value: values[i]}(callData);
+
+            // Revert if the call failed
+            require(success, "ProposalExecutor: call failed");
+        }
+    }
+}

--- a/contracts/executor/AxelarProposalExecutor.sol
+++ b/contracts/executor/AxelarProposalExecutor.sol
@@ -30,6 +30,8 @@ contract AxelarProposalExecutor is Ownable, IAxelarExecutable, Initializable {
     );
     event ProposalExecuted(bytes32 indexed payloadHash);
 
+    error ProposalExecuteFailed();
+
     modifier onlyWhitelistedCaller(string calldata chain, address caller) {
         require(
             chainWhitelistedCallers[chain][caller],

--- a/deploy/03-deploy-proposal-executor.ts
+++ b/deploy/03-deploy-proposal-executor.ts
@@ -7,14 +7,14 @@ const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const [deployer] = await hre.getUnnamedAccounts();
 
   if (process.env.test === "true") {
-    const { address } = await deploy("InterchainProposalExecutor", {
+    const { address } = await deploy("ProposalExecutor", {
       from: deployer,
       args: [],
     });
 
-    console.log("Deployed InterchainProposalExecutor:", address);
+    console.log("Deployed ProposalExecutor:", address);
   } else {
-    const { deploy } = await deterministic("InterchainProposalExecutor", {
+    const { deploy } = await deterministic("ProposalExecutor", {
       from: deployer,
       salt: hre.ethers.utils.id(deployer + "v1"),
       args: [],
@@ -22,10 +22,10 @@ const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
     const receipt = await deploy();
 
-    console.log("Deployed InterchainProposalExecutor:", receipt.address);
+    console.log("Deployed ProposalExecutor:", receipt.address);
   }
 };
 
-deploy.tags = ["InterchainProposalExecutor"];
+deploy.tags = ["ProposalExecutor"];
 
 export default deploy;

--- a/deploy/04-init-proposal-executor.ts
+++ b/deploy/04-init-proposal-executor.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 import { contracts } from "../constants";
 
-const contractName = "InterchainProposalExecutor";
+const contractName = "ProposalExecutor";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { execute, read } = hre.deployments;

--- a/deploy/05-verify-contracts.ts
+++ b/deploy/05-verify-contracts.ts
@@ -6,7 +6,7 @@ const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const verifyContractNames = [
     "InterchainProposalSender",
-    "InterchainProposalExecutor",
+    "ProposalExecutor",
   ];
 
   for (const contractName of verifyContractNames) {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide will walk you through the process of deploying `InterchainProposalExecutor` and `InterchainProposalSender` contracts.
+This guide will walk you through the process of deploying `ProposalExecutor` and `InterchainProposalSender` contracts.
 
 ## Prerequisites
 
@@ -13,13 +13,13 @@ Before starting, make sure to complete the following steps:
 
 Here's how you can deploy the contracts:
 
-- To deploy the `InterchainProposalExecutor` contract only, use the following command:
+- To deploy the `ProposalExecutor` contract only, use the following command:
 
 ```bash
- yarn deploy --tags InterchainProposalExecutor --network {chainName}
+ yarn deploy --tags ProposalExecutor --network {chainName}
 ```
 
-- To deploy both `InterchainProposalExecutor` and `InterchainProposalSender` contracts, use the following command:
+- To deploy both `ProposalExecutor` and `InterchainProposalSender` contracts, use the following command:
 
 ```bash
 yarn deploy --network {chainName}
@@ -32,9 +32,9 @@ Run the following command:
 yarn deploy --tags VerifyContract --network {chainName}
 ```
 
-## Setting Up the InterchainProposalExecutor Contract
+## Setting Up the ProposalExecutor Contract
 
-You may need to whitelist certain contracts for your `InterchainProposalExecutor` contract. Here's how you can do that:
+You may need to whitelist certain contracts for your `ProposalExecutor` contract. Here's how you can do that:
 
 1. To whitelist the `InterchainProposalSender` contract, use the following command:
 

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -4,7 +4,7 @@ This document outlines how to create a proposal that sets a new string value in 
 
 ## Prerequisites
 
-You must have deployed instances of `InterchainProposalSender` and `InterchainProposalExecutor`. Your `InterchainProposalSender` must be whitelisted for the `InterchainProposalExecutor`.
+You must have deployed instances of `InterchainProposalSender` and `ProposalExecutor`. Your `InterchainProposalSender` must be whitelisted for the `ProposalExecutor`.
 
 ## Code Snippet
 
@@ -24,8 +24,8 @@ const governorAlphaABI = [...];
 
 // Contract addresses
 const DummyContractAddressOnAvalanche = "0xDummyContractAddressOnAvalanche";
-const InterchainProposalExecutorAddressOnAvalanche =
-  "0xInterchainProposalExecutorAddressOnAvalanche";
+const ProposalExecutorAddressOnAvalanche =
+  "0xProposalExecutorAddressOnAvalanche";
 const GovernorAlphaAddressOnEthereum = "0xGovernorAlphaAddressOnEthereum";
 const InterchainProposalSenderAddressOnEthereum =
   "0xInterchainProposalSenderAddressOnEthereum";
@@ -97,7 +97,7 @@ await governorAlphaContract.propose(
       ["string", "string", "bytes"],
       [
         "Avalanche",
-        InterchainProposalExecutorAddressOnAvalanche,
+        ProposalExecutorAddressOnAvalanche,
         proposalPayload,
       ]
     ),

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "engines": {
+    "node": ">=16 < 17"
+  },
   "scripts": {
     "deploy": "hardhat deploy",
     "test": "TEST=true hardhat test",

--- a/tasks/whitelistProposalCaller.ts
+++ b/tasks/whitelistProposalCaller.ts
@@ -1,5 +1,5 @@
 import { task } from "hardhat/config";
-import { InterchainProposalExecutor } from "../typechain-types/contracts/InterchainProposalExecutor";
+import { ProposalExecutor } from "../typechain-types/contracts/ProposalExecutor";
 
 task("whitelistCaller", "Whitelist proposal caller")
   .addPositionalParam("sourceChain")
@@ -10,8 +10,8 @@ task("whitelistCaller", "Whitelist proposal caller")
     const ethers = hre.ethers;
 
     // get executor contract
-    const executor = await ethers.getContract<InterchainProposalExecutor>(
-      "InterchainProposalExecutor"
+    const executor = await ethers.getContract<ProposalExecutor>(
+      "ProposalExecutor"
     );
 
     const tx = await executor.setWhitelistedProposalCaller(

--- a/tasks/whitelistProposalSender.ts
+++ b/tasks/whitelistProposalSender.ts
@@ -1,5 +1,5 @@
 import { task } from "hardhat/config";
-import { InterchainProposalExecutor } from "../typechain-types/contracts/InterchainProposalExecutor";
+import { ProposalExecutor } from "../typechain-types/contracts/ProposalExecutor";
 
 task("whitelistSender", "Whitelist proposal sender")
   .addPositionalParam("sourceChain")
@@ -9,8 +9,8 @@ task("whitelistSender", "Whitelist proposal sender")
     const ethers = hre.ethers;
 
     // get executor contract
-    const executor = await ethers.getContract<InterchainProposalExecutor>(
-      "InterchainProposalExecutor"
+    const executor = await ethers.getContract<ProposalExecutor>(
+      "ProposalExecutor"
     );
 
     const tx = await executor.setWhitelistedProposalSender(

--- a/test/interchain-proposal.test.ts
+++ b/test/interchain-proposal.test.ts
@@ -6,7 +6,7 @@ import {
   deployComp,
   deployDummyState,
   deployGovernorAlpha,
-  deployInterchainProposalExecutor,
+  deployProposalExecutor,
   deployInterchainProposalSender,
   deployTimelock,
 } from "./utils/deploy";
@@ -41,7 +41,7 @@ describe("Interchain Proposal", function () {
 
     // Deploy contracts
     sender = await deployInterchainProposalSender(deployer);
-    executor = await deployInterchainProposalExecutor(deployer);
+    executor = await deployProposalExecutor(deployer);
     comp = await deployComp(deployer);
     timelock = await deployTimelock(deployer);
 
@@ -77,7 +77,7 @@ describe("Interchain Proposal", function () {
     await stop();
   });
 
-  it.only("should execute a proposal with a single destination target contract", async function () {
+  it("should execute a proposal with a single destination target contract", async function () {
     // Encode the payload for the destination chain
     const payload = ethers.utils.defaultAbiCoder.encode(
       ["address[]", "uint256[]", "string[]", "bytes[]"],

--- a/test/utils/deploy.ts
+++ b/test/utils/deploy.ts
@@ -28,12 +28,12 @@ export async function deployInterchainProposalSender(deployer: Wallet) {
   return contract;
 }
 
-export async function deployInterchainProposalExecutor(deployer: Wallet) {
+export async function deployProposalExecutor(deployer: Wallet) {
   const chains = getChains();
   const contract = await deploy(
     deployer,
     chains[1].rpc,
-    "InterchainProposalExecutor",
+    "ProposalExecutor",
     []
   );
 


### PR DESCRIPTION
# Summary

This Pull Request provides a significant refactor to the `InterchainProposalExecutor` contract. The contract has been split into two separate classes to enhance clarity, reduce complexity and streamline user interaction. 

## Motivation

The main reason behind this refactor is to abstract away implementation details, ensuring that users interact with only what's necessary for their use case. This division also creates a clear separation of concerns, enhancing the contract's maintainability and readability.

## Changes

The `InterchainProposalExecutor` has been divided into two contracts:

1. `AxelarProposalExecutor`: This is the parent class that handles the core functionality including initialization, proposal execution and whitelisting of callers and senders.

2. `ProposalExecutor`: This child class inherits from the `AxelarProposalExecutor` and implements the `_executeProposal` method, which is left abstract in the parent class. This contract is designed for developers to deploy if they want to receive governance execution by Axelar from the EVM source chain.

The `AxelarProposalExecutor` takes care of the heavy lifting such as validating contracts and setup contract permissions, while the `ProposalExecutor` allows developers to focus on their specific execution logic.

## Impact

The separation of the two contracts simplifies the user's interaction with the system, as they are only exposed to the parts relevant to their requirements. This abstraction also makes the system more robust and easier to maintain, as changes can be made to one contract without affecting the other.

In addition, this refactoring introduces event emission when a new address is whitelisted, which can provide helpful insights for tracking contract activity.